### PR TITLE
Updated units for BoC, GloomGitz, LumLords, MonstersChaos, and SoB

### DIFF
--- a/data/armies/gloomspite_gitz.json
+++ b/data/armies/gloomspite_gitz.json
@@ -4,44 +4,97 @@
     {
       "name": "Aleguzzler Gargant",
       "size": "90 x 52 mm",
-      "move": "",
-      "save": "",
-      "bravery": "",
-      "wounds": "",
-      "missile_weapon": [
-        {
-          "name": "",
-          "range": "",
-          "attacks": "",
-          "to_hit": "",
-          "to_wound": "",
-          "rend": "",
-          "damage": ""
-        }
-      ],
+      "move": "See Damage Table",
+      "save": "5+",
+      "bravery": "6",
+      "wounds": "12",
       "melee_weapon": [
         {
-          "name": "",
-          "range": "",
-          "attacks": "",
-          "to_hit": "",
-          "to_wound": "",
-          "rend": "",
-          "damage": ""
+          "name": "'Eadbutt'",
+          "range": "1",
+          "attacks": "1",
+          "to_hit": "4+",
+          "to_wound": "3+",
+          "rend": "-3",
+          "damage": "See Damage Table"
+        },
+        {
+          "name": "Massive Club",
+          "range": "3",
+          "attacks": "See Damage Table",
+          "to_hit": "3+",
+          "to_wound": "3+",
+          "rend": "-1",
+          "damage": "1"
+        },
+        {
+          "name": "Mighty Kick",
+          "range": "2",
+          "attacks": "1",
+          "to_hit": "3+",
+          "to_wound": "3+",
+          "rend": "-2",
+          "damage": "D3"
         }
       ],
       "abilites": [
         {
-          "name": "",
-          "desc": ""
+          "name": "Drunken Stagger",
+          "desc": "If a charge roll for this model is a double, this model cannot make a charge move that phase. In addition, the players must roll off. The player who wins the roll-off picks a point on the battlefield 3\" from this model. Each unit within 2\" of that point suffers D3 mortal wounds."
         },
         {
-          "name": "",
-          "desc": ""
+          "name": "Stuff'Em In Me Bag",
+          "desc": "After this model piles in, you can pick 1 enemy model within 3\" of this model and roll a dice. If the roll is equal to or greater than double that model’s Wounds characteristic, it is slain."
+        },
+        {
+          "name": "Timber!",
+          "desc": "If this model is slain, before removing the model from the battlefield the players must roll off. The player who wins the roll-off picks a point on the battlefield 3\" from this model. Each unit within 2\" of that point suffers D3 mortal wounds. This model is then removed from the battlefield."
         }
       ],
+      "damage_table": [
+        {
+          "wound_track_position": "1",
+          "move": "8",
+          "massive_club": "3D6",
+          "'eadbutt": "D6",
+          "min_wounds_suffered": "0"
+        },
+        {
+          "wound_track_position": "2",
+          "move": "6",
+          "massive_club": "2D6",
+          "'eadbutt": "D6",
+          "min_wounds_suffered": "3"
+        },
+        {
+          "wound_track_position": "3",
+          "move": "5",
+          "massive_club": "2D6",
+          "'eadbutt": "D3",
+          "min_wounds_suffered": "5"
+        },
+        {
+          "wound_track_position": "4",
+          "move": "4",
+          "massive_club": "D6",
+          "'eadbutt": "D3",
+          "min_wounds_suffered": "8"
+        },
+        {
+          "wound_track_position": "5",
+          "move": "3",
+          "massive_club": "D6",
+          "'eadbutt": "1",
+          "min_wounds_suffered": "10"
+        }
+        
+      ],
       "keywords": [
-        ""
+        "DESTRUCTION",
+        "GARGANT",
+        "GLOOMSPITE GITZ",
+        "ALEGUZZLER",
+        "MONSTER"
       ]
     },
     {

--- a/data/armies/lumineth_realm_lords.json
+++ b/data/armies/lumineth_realm_lords.json
@@ -1,282 +1,338 @@
 {
-  "army": "Beasts of Chaos",
+  "army": "Fyreslayers",
   "units": [
     {
-      "name": "Beastlord",
-      "size": "32mm",
-      "move": "",
-      "save": "",
-      "bravery": "",
-      "wounds": "",
-      "missile_weapon": [
-        {
-          "name": "",
-          "range": "",
-          "attacks": "",
-          "to_hit": "",
-          "to_wound": "",
-          "rend": "",
-          "damage": ""
-        }
-      ],
+      "name": "Vanari Dawnriders",
+      "size": "60 x 35 mm",
+      "move": "14",
+      "save": "4+",
+      "bravery": "7",
+      "wounds": "2",
       "melee_weapon": [
         {
-          "name": "",
-          "range": "",
-          "attacks": "",
-          "to_hit": "",
-          "to_wound": "",
-          "rend": "",
-          "damage": ""
-        }
-      ],
-      "abilites": [
-        {
-          "name": "",
-          "desc": ""
-        },
-        {
-          "name": "",
-          "desc": ""
-        }
-      ],
-      "keywords": [
-        ""
-      ]
-    },
-    {
-      "name": "Bestigors",
-      "size": "32mm",
-      "move": "",
-      "save": "",
-      "bravery": "",
-      "wounds": "",
-      "missile_weapon": [
-        {
-          "name": "",
-          "range": "",
-          "attacks": "",
-          "to_hit": "",
-          "to_wound": "",
-          "rend": "",
-          "damage": ""
-        }
-      ],
-      "melee_weapon": [
-        {
-          "name": "",
-          "range": "",
-          "attacks": "",
-          "to_hit": "",
-          "to_wound": "",
-          "rend": "",
-          "damage": ""
-        }
-      ],
-      "abilites": [
-        {
-          "name": "",
-          "desc": ""
-        },
-        {
-          "name": "",
-          "desc": ""
-        }
-      ],
-      "keywords": [
-        ""
-      ]
-    },
-    {
-      "name": "Bullgors",
-      "size": "50mm",
-      "move": "",
-      "save": "",
-      "bravery": "",
-      "wounds": "",
-      "missile_weapon": [
-        {
-          "name": "",
-          "range": "",
-          "attacks": "",
-          "to_hit": "",
-          "to_wound": "",
-          "rend": "",
-          "damage": ""
-        }
-      ],
-      "melee_weapon": [
-        {
-          "name": "",
-          "range": "",
-          "attacks": "",
-          "to_hit": "",
-          "to_wound": "",
-          "rend": "",
-          "damage": ""
-        }
-      ],
-      "abilites": [
-        {
-          "name": "",
-          "desc": ""
-        },
-        {
-          "name": "",
-          "desc": ""
-        }
-      ],
-      "keywords": [
-        ""
-      ]
-    },
-    {
-      "name": "Centigors",
-      "size": "60 x 35mm",
-      "move": "",
-      "save": "",
-      "bravery": "",
-      "wounds": "",
-      "missile_weapon": [
-        {
-          "name": "",
-          "range": "",
-          "attacks": "",
-          "to_hit": "",
-          "to_wound": "",
-          "rend": "",
-          "damage": ""
-        }
-      ],
-      "melee_weapon": [
-        {
-          "name": "",
-          "range": "",
-          "attacks": "",
-          "to_hit": "",
-          "to_wound": "",
-          "rend": "",
-          "damage": ""
-        }
-      ],
-      "abilites": [
-        {
-          "name": "",
-          "desc": ""
-        },
-        {
-          "name": "",
-          "desc": ""
-        }
-      ],
-      "keywords": [
-        ""
-      ]
-    },
-    {
-      "name": "Chaos Gargant",
-      "size": "90 x 52 mm",
-      "move": "See Damage Table",
-      "save": "5+",
-      "bravery": "6",
-      "wounds": "12",
-      "melee_weapon": [
-        {
-          "name": "Vicious 'Eadbutt'",
+          "name": "Guardian's Sword",
           "range": "1",
-          "attacks": "1",
-          "to_hit": "4+",
-          "to_wound": "3+",
-          "rend": "-3",
-          "damage": "See Damage Table"
-        },
-        {
-          "name": "Massive Club",
-          "range": "3",
-          "attacks": "See Damage Table",
+          "attacks": "2",
           "to_hit": "3+",
-          "to_wound": "3+",
+          "to_wound": "4+",
           "rend": "-1",
           "damage": "1"
         },
         {
-          "name": "Mighty Kick",
+          "name": "Sunmetal Lance",
           "range": "2",
           "attacks": "1",
           "to_hit": "3+",
-          "to_wound": "3+",
-          "rend": "-2",
-          "damage": "D3"
+          "to_wound": "4+",
+          "rend": "-",
+          "damage": "1"
+        },
+        {
+          "name": "Dashing Hooves",
+          "range": "1",
+          "attacks": "2",
+          "to_hit": "4+",
+          "to_wound": "4+",
+          "rend": "-",
+          "damage": "1"
         }
       ],
       "abilites": [
         {
-          "name": "Drunken Stagger",
-          "desc": "If a charge roll for this model is a double, this model cannot make a charge move that phase. In addition, the players must roll off. The player who wins the roll-off picks a point on the battlefield 3\" from this model. Each unit within 2\" of that point suffers D3 mortal wounds."
+          "name": "Deathly Furrows",
+          "desc": "At the start of the combat phase, you can say that this unit will use its Deathly Furrows ability. If you do so, in that phase, you can either add 1 to the Attacks characteristic of this unit’s melee weapons, but it can only target units that have a Wounds characteristic of 1 or 2 and do not have a mount, or you can add 2 to the Attacks characteristic of this unit’s melee weapons, but it can only target units that have a Wounds characteristic of 1 and do not have a mount."
         },
         {
-          "name": "Stuff'Em In Me Bag",
-          "desc": "After this model piles in, you can pick 1 enemy model within 3\" of this model and roll a dice. If the roll is equal to or greater than double that model’s Wounds characteristic, it is slain."
+          "name": "Lances of the Dawn",
+          "desc": "If this unit made a charge move in the same turn, add 1 to wound rolls for attacks made with this unit’s Sunmetal Lances and improve the Rend characteristic of that weapon by 1."
         },
         {
-          "name": "Whipped into a Frenzy",
-          "desc": "At the start of the combat phase, if this model is within 3\" of any friendly Beasts of Chaos Heroes, you can whip it into a frenzy. If you do so, this model suffers 1 mortal wound, but you can add 1 to the Attacks characteristic of this model’s melee weapons until the end of that phase."
+          "name": "Sunmetal Weapons",
+          "desc": "If the unmodified hit roll for an attack made with a Sunmetal Lance is 6, that attack inflicts 1 mortal wound on the target and the attack sequence ends (do not make a wound or save roll)."
+        }
+      ],
+      "magic": [
+        {
+          "name": "Power of Hysh",
+          "desc": "Power of Hysh has a casting value of 6. If successfully cast, until your next hero phase, the Sunmetal Weapons ability for the caster and/or the unit they are part of causes mortal wounds to be inflicted on an unmodified hit roll of 5+ instead of 6."
+        }
+      ],
+      "keywords": [
+        "ORDER",
+        "AELF",
+        "LUMINETH REALM-LORDS",
+        "VANARI",
+        "DAWNRIDERS"
+      ]
+    },
+    {
+      "name": "Avalenor The Stoneheart King",
+      "size": "100 mm",
+      "move": "6",
+      "save": "3+",
+      "bravery": "10",
+      "wounds": "14",
+      "missile_weapon": [
+        {
+          "name": "Geomantic Blast",
+          "range": "See Damage Table",
+          "attacks": "1",
+          "to_hit": "3+",
+          "to_wound": "2+",
+          "rend": "-2",
+          "damage": "D6"
+        }
+      ],
+      "melee_weapon": [
+        {
+          "name": "Firestealer Hammers",
+          "range": "2",
+          "attacks": "6",
+          "to_hit": "3+",
+          "to_wound": "3+",
+          "rend": "-1",
+          "damage": "See Damage Table"
         },
         {
-          "name": "Timber!",
-          "desc": "If this model is slain, before removing the model from the battlefield the players must roll off. The player who wins the roll-off picks a point on the battlefield 3\" from this model. Each unit within 2\" of that point suffers D3 mortal wounds. This model is then removed from the battlefield."
+          "name": "Cloven Hooves",
+          "range": "1",
+          "attacks": "2",
+          "to_hit": "3+",
+          "to_wound": "3+",
+          "rend": "-1",
+          "damage": "2"
+        }
+      ],
+      "abilites": [
+        {
+          "name": "All but Immovable",
+          "desc": "If this model does not make a charge move in your charge phase, add 1 to the Attacks characteristic of this model’s melee weapons until your next movement phase. "
+        },
+        {
+          "name": "Firestealer Hammers",
+          "desc": "If the unmodified hit roll for an attack made with the Firestealer Hammers is 6, that attack inflicts 1 mortal wound on the target in addition to any normal damage."
+        },
+        {
+          "name": "Elder Wisdom",
+          "desc": "At the end of your hero phase, you can pick 1 friendly Lumineth Realm-lords Aelf Hero within 6\" of this model. If that Lumineth Realm-lords Aelf Hero is within 6\" of this model at the start of your next hero phase, then that Lumineth Realm-lords Aelf Hero can use a command ability in that turn without spending any command points."
+        },
+        {
+          "name": "Guardian of Hysh",
+          "desc": "Subtract 1 from hit rolls for attacks made by enemy models that are within range of this model’s Guardian of Hysh ability. The range of the Guardian of Hysh ability for this model is shown on the damage table."
+        },
+        {
+          "name": "Stonemage Symbiosis",
+          "desc": "When you look up a value on this model’s damage table, if this model is within 12\" of a friendly Stonemage, this model is treated as if it has suffered 0 wounds."
+        }
+      ],
+      "command_abilites": [
+        {
+          "name": "Unshakeable Faith of the Mountains",
+          "desc": "You can use this command ability at the start of the combat phase. If you do so, pick up to D3 friendly Alarith Aelf units wholly within 24\" of a friendly model with this command ability. Add 1 to the Attacks characteristic of those units’ melee weapons in that combat phase. A unit cannot benefit from this command ability more than once per combat phase, and a unit cannot benefit from this ability and the Faith of the Mountains command ability in the same phase."
         }
       ],
       "damage_table": [
         {
           "wound_track_position": "1",
-          "move": "8",
-          "massive_club": "3D6",
-          "vicious_'eadbutt": "6",
+          "geomantic_blast": "30",
+          "guardian_of_hysh": "12",
+          "firestealer_hammers": "5",
           "min_wounds_suffered": "0"
         },
         {
           "wound_track_position": "2",
-          "move": "6",
-          "massive_club": "2D6",
-          "vicious'eadbutt": "D6",
+          "geomantic_blast": "25",
+          "guardian_of_hysh": "6",
+          "firestealer_hammers": "4",
+          "min_wounds_suffered": "4"
+        },
+        {
+          "wound_track_position": "3",
+          "geomantic_blast": "20",
+          "guardian_of_hysh": "3",
+          "firestealer_hammers": "3",
+          "min_wounds_suffered": "7"
+        },
+        {
+          "wound_track_position": "4",
+          "geomantic_blast": "15",
+          "guardian_of_hysh": "2",
+          "firestealer_hammers": "2",
+          "min_wounds_suffered": "10"
+        },
+        {
+          "wound_track_position": "5",
+          "geomantic_blast": "10",
+          "guardian_of_hysh": "1",
+          "firestealer_hammers": "1",
+          "min_wounds_suffered": "13"
+        }
+      ],
+      "keywords": [
+        "ORDER",
+        "LUMINETH REALM-LORDS",
+        "ALARITH",
+        "YMETRICA",
+        "MONSTER",
+        "HERO",
+        "SPIRIT OF THE MOUNTAIN",
+        "AVALENOR"
+      ]
+    },
+    {
+      "name": "Alarith Spirit of the Mountain",
+      "size": "100 mm",
+      "move": "6",
+      "save": "3+",
+      "bravery": "10",
+      "wounds": "12",
+      "missile_weapon": [
+        {
+          "name": "Geomantic Blast",
+          "range": "See Damage Table",
+          "attacks": "1",
+          "to_hit": "3+",
+          "to_wound": "2+",
+          "rend": "-2",
+          "damage": "D6"
+        }
+      ],
+      "melee_weapon": [
+        {
+          "name": "Stoneheart Worldhammer",
+          "range": "3",
+          "attacks": "4",
+          "to_hit": "3+",
+          "to_wound": "2+",
+          "rend": "-2",
+          "damage": "See Damage Table"
+        },
+        {
+          "name": "Cloven Hooves",
+          "range": "1",
+          "attacks": "2",
+          "to_hit": "3+",
+          "to_wound": "3+",
+          "rend": "-1",
+          "damage": "2"
+        }
+      ],
+      "abilites": [
+        {
+          "name": "All but Immovable",
+          "desc": "If this model does not make a charge move in your charge phase, add 1 to the Attacks characteristic of this model’s melee weapons until your next movement phase. "
+        },
+        {
+          "name": "Ponderous Advice",
+          "desc": "At the end of your hero phase, you can pick 1 friendly Lumineth Realm-lords Aelf Hero within 3\" of this model. If that Lumineth Realm-lords Aelf Hero is within 3\" of this model at the start of your next hero phase, then that Lumineth Realm-lords Aelf Hero can use a command ability in that turn without spending any command points."
+        },
+        {
+          "name": "Stoneheart Shockwave",
+          "desc": "At the start of the enemy shooting phase and at the start of any combat phase, you can pick 1 enemy unit within range of this model’s Stoneheart Shockwave ability that is visible to this model. The range of the Stoneheart Shockwave ability for this model is shown on the damage table. If you do so, subtract 1 from hit rolls for that unit until the end of that phase. A unit cannot be affected by this ability more than once per phase."
+        },
+        {
+          "name": "Stonemage Symbiosis",
+          "desc": "When you look up a value on this model’s damage table, if this model is within 12\" of a friendly Stonemage, this model is treated as if it has suffered 0 wounds."
+        }
+      ],
+      "command_abilites": [
+        {
+          "name": "Faith of the Mountains",
+          "desc": "You can use this command ability at the start of the combat phase. If you do so, pick 1 friendly Alarith Aelf unit wholly within 18\" of a friendly model with this command ability. Add 1 to the Attacks characteristic of that unit’s melee weapons in that combat phase. A unit cannot benefit from this command ability more than once per combat phase, and a unit cannot benefit from this ability and the Unshakeable Faith of the Mountains command ability in the same phase."
+        }
+      ],
+      "damage_table": [
+        {
+          "wound_track_position": "1",
+          "geomantic_blast": "30",
+          "stoneheart_shockwave": "12",
+          "stoneheart_worldhammer": "5",
+          "min_wounds_suffered": "0"
+        },
+        {
+          "wound_track_position": "2",
+          "geomantic_blast": "25",
+          "stoneheart_shockwave": "10",
+          "stoneheart_worldhammer": "4",
           "min_wounds_suffered": "3"
         },
         {
           "wound_track_position": "3",
-          "move": "5",
-          "massive_club": "2D6",
-          "vicious'eadbutt": "D3",
-          "min_wounds_suffered": "5"
+          "geomantic_blast": "20",
+          "stoneheart_shockwave": "8",
+          "stoneheart_worldhammer": "3",
+          "min_wounds_suffered": "6"
         },
         {
           "wound_track_position": "4",
-          "move": "4",
-          "massive_club": "D6",
-          "vicious'eadbutt": "D3",
+          "geomantic_blast": "15",
+          "stoneheart_shockwave": "6",
+          "stoneheart_worldhammer": "2",
           "min_wounds_suffered": "8"
         },
         {
           "wound_track_position": "5",
-          "move": "3",
-          "massive_club": "D6",
-          "vicious'eadbutt": "1",
-          "min_wounds_suffered": "10"
+          "geomantic_blast": "10",
+          "stoneheart_shockwave": "4",
+          "stoneheart_worldhammer": "1",
+          "min_wounds_suffered": "11"
         }
-        
       ],
       "keywords": [
-        "CHAOS",
-        "BEASTS OF CHAOS",
-        "MONSTERS OF CHAOS",
-        "GARGANT",
+        "ORDER",
+        "LUMINETH REALM-LORDS",
+        "ALARITH",
         "MONSTER",
-        "CHAOS GARGANT"
+        "SPIRIT OF THE MOUNTAIN"
       ]
     },
     {
-      "name": "Chaos Warhounds",
-      "size": "60 x 35mm",
+      "name": "",
+      "size": "120 x 92 mm",
+      "move": "",
+      "save": "",
+      "bravery": "",
+      "wounds": "",
+      "missile_weapon": [
+        {
+          "name": "",
+          "range": "",
+          "attacks": "",
+          "to_hit": "",
+          "to_wound": "",
+          "rend": "",
+          "damage": ""
+        }
+      ],
+      "melee_weapon": [
+        {
+          "name": "",
+          "range": "",
+          "attacks": "",
+          "to_hit": "",
+          "to_wound": "",
+          "rend": "",
+          "damage": ""
+        }
+      ],
+      
+      "abilites": [
+        {
+          "name": "",
+          "desc": ""
+        },
+        {
+          "name": "",
+          "desc": ""
+        }
+      ],
+      "keywords": [
+        ""
+      ]
+    },   
+    {
+      "name": "Auric Runemaster",
+      "size": "32 mm",
       "move": "",
       "save": "",
       "bravery": "",
@@ -318,8 +374,8 @@
       ]
     },
     {
-      "name": "Chimera",
-      "size": "120 x 92mm",
+      "name": "Auric Runesmiter",
+      "size": "32 mm",
       "move": "",
       "save": "",
       "bravery": "",
@@ -361,8 +417,8 @@
       ]
     },
     {
-      "name": "Cockatrice",
-      "size": "60mm",
+      "name": "Auric Runesmiter on Magmadroth",
+      "size": "120 x 92 mm",
       "move": "",
       "save": "",
       "bravery": "",
@@ -404,8 +460,8 @@
       ]
     },
     {
-      "name": "Cygor",
-      "size": "120 x 92mm",
+      "name": "Auric Runeson",
+      "size": "32 mm",
       "move": "",
       "save": "",
       "bravery": "",
@@ -447,8 +503,8 @@
       ]
     },
     {
-      "name": "Doomblast Dirgehorn",
-      "size": "40mm",
+      "name": "Auric Runeson on Magmadroth",
+      "size": "120 x 92 mm",
       "move": "",
       "save": "",
       "bravery": "",
@@ -490,8 +546,8 @@
       ]
     },
     {
-      "name": "Doombull",
-      "size": "50mm",
+      "name": "Battlesmith",
+      "size": "32 mm",
       "move": "",
       "save": "",
       "bravery": "",
@@ -533,8 +589,8 @@
       ]
     },
     {
-      "name": "Dragon Ogor Shaggoth",
-      "size": "90 x 52mm",
+      "name": "Doomseeker",
+      "size": "32 mm",
       "move": "",
       "save": "",
       "bravery": "",
@@ -576,8 +632,8 @@
       ]
     },
     {
-      "name": "Dragon Ogors",
-      "size": "90 x 52mm",
+      "name": "Fjul-Grimnir",
+      "size": "32 mm",
       "move": "",
       "save": "",
       "bravery": "",
@@ -619,8 +675,8 @@
       ]
     },
     {
-      "name": "Ghorgon",
-      "size": "120 x 92mm",
+      "name": "Grimwrath Berzerker",
+      "size": "32 mm",
       "move": "",
       "save": "",
       "bravery": "",
@@ -662,8 +718,8 @@
       ]
     },
     {
-      "name": "Gors",
-      "size": "32mm",
+      "name": "Hearthguard Berzerkers",
+      "size": "32 mm",
       "move": "",
       "save": "",
       "bravery": "",
@@ -705,8 +761,8 @@
       ]
     },
     {
-      "name": "Great Bray-Shaman",
-      "size": "32mm",
+      "name": "The Chosen Axes",
+      "size": "32 mm",
       "move": "",
       "save": "",
       "bravery": "",
@@ -748,266 +804,8 @@
       ]
     },
     {
-      "name": "Jabberslythe",
-      "size": "120 x 92mm",
-      "move": "",
-      "save": "",
-      "bravery": "",
-      "wounds": "",
-      "missile_weapon": [
-        {
-          "name": "",
-          "range": "",
-          "attacks": "",
-          "to_hit": "",
-          "to_wound": "",
-          "rend": "",
-          "damage": ""
-        }
-      ],
-      "melee_weapon": [
-        {
-          "name": "",
-          "range": "",
-          "attacks": "",
-          "to_hit": "",
-          "to_wound": "",
-          "rend": "",
-          "damage": ""
-        }
-      ],
-      "abilites": [
-        {
-          "name": "",
-          "desc": ""
-        },
-        {
-          "name": "",
-          "desc": ""
-        }
-      ],
-      "keywords": [
-        ""
-      ]
-    },
-    {
-      "name": "Ravening Direflock",
-      "size": "40mm",
-      "move": "",
-      "save": "",
-      "bravery": "",
-      "wounds": "",
-      "missile_weapon": [
-        {
-          "name": "",
-          "range": "",
-          "attacks": "",
-          "to_hit": "",
-          "to_wound": "",
-          "rend": "",
-          "damage": ""
-        }
-      ],
-      "melee_weapon": [
-        {
-          "name": "",
-          "range": "",
-          "attacks": "",
-          "to_hit": "",
-          "to_wound": "",
-          "rend": "",
-          "damage": ""
-        }
-      ],
-      "abilites": [
-        {
-          "name": "",
-          "desc": ""
-        },
-        {
-          "name": "",
-          "desc": ""
-        }
-      ],
-      "keywords": [
-        ""
-      ]
-    },
-    {
-      "name": "Razorgors",
-      "size": "75 x 42mm",
-      "move": "",
-      "save": "",
-      "bravery": "",
-      "wounds": "",
-      "missile_weapon": [
-        {
-          "name": "",
-          "range": "",
-          "attacks": "",
-          "to_hit": "",
-          "to_wound": "",
-          "rend": "",
-          "damage": ""
-        }
-      ],
-      "melee_weapon": [
-        {
-          "name": "",
-          "range": "",
-          "attacks": "",
-          "to_hit": "",
-          "to_wound": "",
-          "rend": "",
-          "damage": ""
-        }
-      ],
-      "abilites": [
-        {
-          "name": "",
-          "desc": ""
-        },
-        {
-          "name": "",
-          "desc": ""
-        }
-      ],
-      "keywords": [
-        ""
-      ]
-    },
-    {
-      "name": "Tuskgor Chariots",
-      "size": "105 x 70mm",
-      "move": "",
-      "save": "",
-      "bravery": "",
-      "wounds": "",
-      "missile_weapon": [
-        {
-          "name": "",
-          "range": "",
-          "attacks": "",
-          "to_hit": "",
-          "to_wound": "",
-          "rend": "",
-          "damage": ""
-        }
-      ],
-      "melee_weapon": [
-        {
-          "name": "",
-          "range": "",
-          "attacks": "",
-          "to_hit": "",
-          "to_wound": "",
-          "rend": "",
-          "damage": ""
-        }
-      ],
-      "abilites": [
-        {
-          "name": "",
-          "desc": ""
-        },
-        {
-          "name": "",
-          "desc": ""
-        }
-      ],
-      "keywords": [
-        ""
-      ]
-    },
-    {
-      "name": "Ungor Raiders",
-      "size": "25mm",
-      "move": "",
-      "save": "",
-      "bravery": "",
-      "wounds": "",
-      "missile_weapon": [
-        {
-          "name": "",
-          "range": "",
-          "attacks": "",
-          "to_hit": "",
-          "to_wound": "",
-          "rend": "",
-          "damage": ""
-        }
-      ],
-      "melee_weapon": [
-        {
-          "name": "",
-          "range": "",
-          "attacks": "",
-          "to_hit": "",
-          "to_wound": "",
-          "rend": "",
-          "damage": ""
-        }
-      ],
-      "abilites": [
-        {
-          "name": "",
-          "desc": ""
-        },
-        {
-          "name": "",
-          "desc": ""
-        }
-      ],
-      "keywords": [
-        ""
-      ]
-    },
-    {
-      "name": "Ungors",
-      "size": "25mm",
-      "move": "",
-      "save": "",
-      "bravery": "",
-      "wounds": "",
-      "missile_weapon": [
-        {
-          "name": "",
-          "range": "",
-          "attacks": "",
-          "to_hit": "",
-          "to_wound": "",
-          "rend": "",
-          "damage": ""
-        }
-      ],
-      "melee_weapon": [
-        {
-          "name": "",
-          "range": "",
-          "attacks": "",
-          "to_hit": "",
-          "to_wound": "",
-          "rend": "",
-          "damage": ""
-        }
-      ],
-      "abilites": [
-        {
-          "name": "",
-          "desc": ""
-        },
-        {
-          "name": "",
-          "desc": ""
-        }
-      ],
-      "keywords": [
-        ""
-      ]
-    },
-    {
-      "name": "Wildfire Taurus",
-      "size": "105 x 70mm",
+      "name": "Vulkite Berzerkers",
+      "size": "32 mm",
       "move": "",
       "save": "",
       "bravery": "",

--- a/data/armies/monsters_of_chaos.json
+++ b/data/armies/monsters_of_chaos.json
@@ -301,6 +301,108 @@
       "keywords": [
         ""
       ]
+    },
+    {
+      "name": "Chaos Gargant",
+      "size": "90 x 52 mm",
+      "move": "See Damage Table",
+      "save": "5+",
+      "bravery": "6",
+      "wounds": "12",
+      "melee_weapon": [
+        {
+          "name": "Vicious 'Eadbutt'",
+          "range": "1",
+          "attacks": "1",
+          "to_hit": "4+",
+          "to_wound": "3+",
+          "rend": "-3",
+          "damage": "See Damage Table"
+        },
+        {
+          "name": "Massive Club",
+          "range": "3",
+          "attacks": "See Damage Table",
+          "to_hit": "3+",
+          "to_wound": "3+",
+          "rend": "-1",
+          "damage": "1"
+        },
+        {
+          "name": "Mighty Kick",
+          "range": "2",
+          "attacks": "1",
+          "to_hit": "3+",
+          "to_wound": "3+",
+          "rend": "-2",
+          "damage": "D3"
+        }
+      ],
+      "abilites": [
+        {
+          "name": "Drunken Stagger",
+          "desc": "If a charge roll for this model is a double, this model cannot make a charge move that phase. In addition, the players must roll off. The player who wins the roll-off picks a point on the battlefield 3\" from this model. Each unit within 2\" of that point suffers D3 mortal wounds."
+        },
+        {
+          "name": "Stuff'Em In Me Bag",
+          "desc": "After this model piles in, you can pick 1 enemy model within 3\" of this model and roll a dice. If the roll is equal to or greater than double that model’s Wounds characteristic, it is slain."
+        },
+        {
+          "name": "Whipped into a Frenzy",
+          "desc": "At the start of the combat phase, if this model is within 3\" of any friendly Beasts of Chaos Heroes, you can whip it into a frenzy. If you do so, this model suffers 1 mortal wound, but you can add 1 to the Attacks characteristic of this model’s melee weapons until the end of that phase."
+        },
+        {
+          "name": "Timber!",
+          "desc": "If this model is slain, before removing the model from the battlefield the players must roll off. The player who wins the roll-off picks a point on the battlefield 3\" from this model. Each unit within 2\" of that point suffers D3 mortal wounds. This model is then removed from the battlefield."
+        }
+      ],
+      "damage_table": [
+        {
+          "wound_track_position": "1",
+          "move": "8",
+          "massive_club": "3D6",
+          "vicious_'eadbutt": "6",
+          "min_wounds_suffered": "0"
+        },
+        {
+          "wound_track_position": "2",
+          "move": "6",
+          "massive_club": "2D6",
+          "vicious'eadbutt": "D6",
+          "min_wounds_suffered": "3"
+        },
+        {
+          "wound_track_position": "3",
+          "move": "5",
+          "massive_club": "2D6",
+          "vicious'eadbutt": "D3",
+          "min_wounds_suffered": "5"
+        },
+        {
+          "wound_track_position": "4",
+          "move": "4",
+          "massive_club": "D6",
+          "vicious'eadbutt": "D3",
+          "min_wounds_suffered": "8"
+        },
+        {
+          "wound_track_position": "5",
+          "move": "3",
+          "massive_club": "D6",
+          "vicious'eadbutt": "1",
+          "min_wounds_suffered": "10"
+        }
+        
+      ],
+      "keywords": [
+        "CHAOS",
+        "BEASTS OF CHAOS",
+        "MONSTERS OF CHAOS",
+        "GARGANT",
+        "MONSTER",
+        "CHAOS GARGANT"
+      ]
     }
+    
   ]
 }

--- a/data/armies/sons_of_behemat.json
+++ b/data/armies/sons_of_behemat.json
@@ -1,0 +1,612 @@
+{
+  "army": "Fyreslayers",
+  "units": [
+    {
+      "name": "Kraken-eater Mega-Gargant",
+      "size": "130 mm",
+      "move": "See Damage Table",
+      "save": "4+",
+      "bravery": "7",
+      "wounds": "35",
+      "missile_weapon": [
+        {
+          "name": "Hurled Debris",
+          "range": "See Damage Table",
+          "attacks": "3",
+          "to_hit": "4+",
+          "to_wound": "3+",
+          "rend": "-1",
+          "damage": "D3"
+        }
+      ],
+      "melee_weapon": [
+        {
+          "name": "Almighty Stomp",
+          "range": "2",
+          "attacks": "2",
+          "to_hit": "3+",
+          "to_wound": "3+",
+          "rend": "-2",
+          "damage": "D3"
+        },
+        {
+          "name": "Death Grip",
+          "range": "3",
+          "attacks": "1",
+          "to_hit": "3+",
+          "to_wound": "2+",
+          "rend": "-3",
+          "damage": "D6"
+        },
+        {
+          "name": "Shipwrecka Warclub",
+          "range": "3",
+          "attacks": "See Damage Table",
+          "to_hit": "3+",
+          "to_wound": "3+",
+          "rend": "-2",
+          "damage": "2"
+        }
+      ],
+      "abilites": [
+        {
+          "name": "Almighty Stomp",
+          "desc": "You can re-roll hit rolls of 1 for Almighty Stomp attacks unless the target is a Monster."
+        },
+        {
+          "name": "Chrushing Charge",
+          "desc": "After this model makes a charge move, roll a dice for each enemy unit within 1\" of this model. On a 2+, that unit suffers D3 mortal wounds if it is a Monster, or D6 mortal wounds if it is not a Monster."
+        },
+        {
+          "name": "Death Grip",
+          "desc": "You can re-roll hit rolls of 1 for Death Grip attacks that target a Monster."
+        },
+        {
+          "name": "Get Orf Me Land!",
+          "desc": "In your hero phase, if you have any models with this ability within 1\" of an objective that you control, you can pick one of those models and say that it will kick the objective away. If you do so, you can move that objective up to 2D6\" to a new position on the battlefield, more than 1\" away from any models, terrain features or other objectives. An objective cannot be kicked away more than once in the same phase."
+        },
+        {
+          "name": "Longshanks",
+          "desc": "When this model makes a normal move, it can ignore models that have a Wounds characteristic of 10 or less and terrain features that are less than 4\" tall at their highest point. It cannot finish the move on top of another model or within 3\" of an enemy model."
+        },
+        {
+          "name": "Son of Behemat",
+          "desc": "If a spell or ability would slay this model without any wounds or mortal wounds being inflicted by the spell or ability, this model suffers D6 mortal wounds instead."
+        },
+        {
+          "name": "Stuff'Em In Me Net",
+          "desc": "After this model piles in, you can pick up to D3 enemy models within 3\" of this model and roll a dice for each of them. If the roll is at least double that model’s Wounds characteristic, it is slain"
+        },
+        {
+          "name": "Terror",
+          "desc": "Subtract 1 from the Bravery characteristic of enemy units if they are within 3\" of any friendly units with this ability."
+        },
+        {
+          "name": "Timberrrrr!",
+          "desc": "If this model is slain, before removing the model from the battlefield, the players must roll off. The winner must pick a point on the battlefield 5\" from this model. Each unit within 3\" of that point suffers D3 mortal wounds unless it is a Mega-Gargant. This model is then removed from the battlefield."
+        }
+      ],
+      "damage_table": [
+        {
+          "wound_track_position": "1",
+          "move": "11",
+          "shipwrecka_warclub": "8",
+          "hurled_debris": "24",
+          "min_wounds_suffered": "0"
+        },
+        {
+          "wound_track_position": "2",
+          "move": "10",
+          "shipwrecka_warclub": "7",
+          "hurled_debris": "21",
+          "min_wounds_suffered": "13"
+        },
+        {
+          "wound_track_position": "3",
+          "move": "9",
+          "shipwrecka_warclub": "7",
+          "hurled_debris": "18",
+          "min_wounds_suffered": "19"
+        },
+        {
+          "wound_track_position": "4",
+          "move": "8",
+          "shipwrecka_warclub": "6",
+          "hurled_debris": "15",
+          "min_wounds_suffered": "25"
+        },
+        {
+          "wound_track_position": "5",
+          "move": "7",
+          "shipwrecka_warclub": "5",
+          "hurled_debris": "12",
+          "min_wounds_suffered": "31"
+        }
+        
+      ],
+      "keywords": [
+        "DESTRUCTION",
+        "SONS OF BEHEMAT",
+        "GARGANT",
+        "MEGA-GARGANT",
+        "MONSTER",
+        "HERO",
+        "KRAKEN-EATER"
+
+      ]
+    },
+    {
+      "name": "Warstomper Mega-Gargant",
+      "size": "130 mm",
+      "move": "See Damage Table",
+      "save": "4+",
+      "bravery": "7",
+      "wounds": "35",
+      "melee_weapon": [
+        {
+          "name": "Death Grip",
+          "range": "3",
+          "attacks": "1",
+          "to_hit": "3+",
+          "to_wound": "2+",
+          "rend": "-3",
+          "damage": "D6"
+        },
+        {
+          "name": "Jump Up and Down",
+          "range": "3",
+          "attacks": "4",
+          "to_hit": "3+",
+          "to_wound": "4+",
+          "rend": "-2",
+          "damage": "D3"
+        },
+        {
+          "name": "Titanic Boulderclub",
+          "range": "3",
+          "attacks": "See Damage Table",
+          "to_hit": "3+",
+          "to_wound": "3+",
+          "rend": "-2",
+          "damage": "2"
+        }
+      ],
+      "abilites": [
+        {
+          "name": "Almighty Jump",
+          "desc": "You can re-roll hit rolls of 1 for Almighty Stomp attacks unless the target is a Monster."
+        },
+        {
+          "name": "Chrushing Charge",
+          "desc": "After this model makes a charge move, roll a dice for each enemy unit within 1\" of this model. On a 2+, that unit suffers D3 mortal wounds if it is a Monster, or D6 mortal wounds if it is not a Monster."
+        },
+        {
+          "name": "Death Grip",
+          "desc": "You can re-roll hit rolls of 1 for Death Grip attacks that target a Monster."
+        },
+        {
+          "name": "Hurled Body",
+          "desc": "Once per combat phase, you can pick 1 enemy model within 3\" of this model and roll a dice. Add the Hurled Body modifier shown on this model’s damage table to the roll. If the roll is at least double that enemy model’s Wounds characteristic, it is slain and you can roll another dice. On a 4+, you can pick an enemy unit within 12\" of this model and visible to it. That unit suffers a number of mortal wounds equal to the Wounds characteristic of the slain model."
+        },
+        {
+          "name": "Longshanks",
+          "desc": "When this model makes a normal move, it can ignore models that have a Wounds characteristic of 10 or less and terrain features that are less than 4\" tall at their highest point. It cannot finish the move on top of another model or within 3\" of an enemy model."
+        },
+        {
+          "name": "Son of Behemat",
+          "desc": "If a spell or ability would slay this model without any wounds or mortal wounds being inflicted by the spell or ability, this model suffers D6 mortal wounds instead."
+        },
+        {
+          "name": "Titanic Boulderclub",
+          "desc": "The Attacks characteristic of a Titanic Boulderclub is equal to the number of enemy models within 3\" of the attacking model. Add the Titanic Boulderclub value on the attacking model’s damage table to the total, and add 4 to the total for each enemy Monster within 3\" of the attacking model. If the modified Attacks characteristic of the Titanic Boulderclub is less than 1, count it as being 1, and if the modified Attacks characteristic of the Titanic Boulderclub is more than 10, count it as being 10."
+        },
+        {
+          "name": "Terror",
+          "desc": "Subtract 1 from the Bravery characteristic of enemy units if they are within 3\" of any friendly units with this ability."
+        },
+        {
+          "name": "Timberrrrr!",
+          "desc": "If this model is slain, before removing the model from the battlefield, the players must roll off. The winner must pick a point on the battlefield 5\" from this model. Each unit within 3\" of that point suffers D3 mortal wounds unless it is a Mega-Gargant. This model is then removed from the battlefield."
+        }
+      ],
+      "damage_table": [
+        {
+          "wound_track_position": "1",
+          "move": "10",
+          "titanic_boulderclub": "+4",
+          "hurled_body": "+2",
+          "min_wounds_suffered": "0"
+        },
+        {
+          "wound_track_position": "2",
+          "move": "9",
+          "titanic_boulderclub": "+3",
+          "hurled_body": "+1",
+          "min_wounds_suffered": "13"
+        },
+        {
+          "wound_track_position": "3",
+          "move": "8",
+          "titanic_boulderclub": "+2",
+          "hurled_body": "0",
+          "min_wounds_suffered": "19"
+        },
+        {
+          "wound_track_position": "4",
+          "move": "7",
+          "titanic_boulderclub": "+1",
+          "hurled_body": "-1",
+          "min_wounds_suffered": "25"
+        },
+        {
+          "wound_track_position": "5",
+          "move": "6",
+          "titanic_boulderclub": "0",
+          "hurled_body": "-2",
+          "min_wounds_suffered": "31"
+        }
+        
+      ],
+      "keywords": [
+        "DESTRUCTION",
+        "SONS OF BEHEMAT",
+        "GARGANT",
+        "MEGA-GARGANT",
+        "MONSTER",
+        "HERO",
+        "WARSTOMPER"
+
+      ]
+    },
+    {
+      "name": "Gatebreaker Mega-Gargant",
+      "size": "130 mm",
+      "move": "See Damage Table",
+      "save": "4+",
+      "bravery": "7",
+      "wounds": "35",
+      "missile_weapon": [
+        {
+          "name": "Hurled Boulder",
+          "range": "See Damage Table",
+          "attacks": "1",
+          "to_hit": "3+",
+          "to_wound": "2+",
+          "rend": "-3",
+          "damage": "4"
+        }
+      ],
+      "melee_weapon": [
+        {
+          "name": "Almighty Stomp",
+          "range": "2",
+          "attacks": "2",
+          "to_hit": "3+",
+          "to_wound": "3+",
+          "rend": "-2",
+          "damage": "D3"
+        },
+        {
+          "name": "Death Grip",
+          "range": "3",
+          "attacks": "1",
+          "to_hit": "3+",
+          "to_wound": "2+",
+          "rend": "-3",
+          "damage": "D6"
+        },
+        {
+          "name": "Fortcrusha Flail",
+          "range": "3",
+          "attacks": "See Damage Table",
+          "to_hit": "4+",
+          "to_wound": "3+",
+          "rend": "-3",
+          "damage": "3"
+        }
+      ],
+      "abilites": [
+        {
+          "name": "Almighty Stomp",
+          "desc": "You can re-roll hit rolls of 1 for Almighty Stomp attacks unless the target is a Monster."
+        },
+        {
+          "name": "Chrushing Charge",
+          "desc": "After this model makes a charge move, roll a dice for each enemy unit within 1\" of this model. On a 2+, that unit suffers D3 mortal wounds if it is a Monster, or D6 mortal wounds if it is not a Monster."
+        },
+        {
+          "name": "Death Grip",
+          "desc": "You can re-roll hit rolls of 1 for Death Grip attacks that target a Monster."
+        },
+        {
+          "name": "Smash Down",
+          "desc": "Add 1 to the damage inflicted by each successful attack made by this model that targets a unit that is part of a garrison or is wholly on or within a terrain feature. In addition, at the end of the combat phase, you can pick 1 terrain feature within 3\" of this model and roll a dice. If the roll is equal to or greater than the Smash Down value on this model’s damage table, that terrain feature is reduced to rubble: all of its scenery rules are replaced with the Deadly scenery rule, and its keywords are changed to Scenery, Rubble."
+        },
+        {
+          "name": "Longshanks",
+          "desc": "When this model makes a normal move, it can ignore models that have a Wounds characteristic of 10 or less and terrain features that are less than 4\" tall at their highest point. It cannot finish the move on top of another model or within 3\" of an enemy model."
+        },
+        {
+          "name": "Son of Behemat",
+          "desc": "If a spell or ability would slay this model without any wounds or mortal wounds being inflicted by the spell or ability, this model suffers D6 mortal wounds instead."
+        },
+        {
+          "name": "Terror",
+          "desc": "Subtract 1 from the Bravery characteristic of enemy units if they are within 3\" of any friendly units with this ability."
+        },
+        {
+          "name": "Timberrrrr!",
+          "desc": "If this model is slain, before removing the model from the battlefield, the players must roll off. The winner must pick a point on the battlefield 5\" from this model. Each unit within 3\" of that point suffers D3 mortal wounds unless it is a Mega-Gargant. This model is then removed from the battlefield."
+        }
+      ],
+      "damage_table": [
+        {
+          "wound_track_position": "1",
+          "move": "12",
+          "fortchrusha_flail": "10",
+          "hurled_boulder": "18",
+          "smash_down": "2+",
+          "min_wounds_suffered": "0"
+        },
+        {
+          "wound_track_position": "2",
+          "move": "11",
+          "fortchrusha_flail": "9",
+          "hurled_boulder": "15",
+          "smash_down": "3+",
+          "min_wounds_suffered": "13"
+        },
+        {
+          "wound_track_position": "3",
+          "move": "10",
+          "fortchrusha_flail": "7",
+          "hurled_boulder": "12",
+          "smash_down": "4+",
+          "min_wounds_suffered": "19"
+        },
+        {
+          "wound_track_position": "4",
+          "move": "9",
+          "fortchrusha_flail": "6",
+          "hurled_boulder": "9",
+          "smash_down": "5+",
+          "min_wounds_suffered": "25"
+        },
+        {
+          "wound_track_position": "5",
+          "move": "8",
+          "fortchrusha_flail": "5",
+          "hurled_boulder": "6",
+          "smash_down": "6+",
+          "min_wounds_suffered": "31"
+        }
+        
+      ],
+      "keywords": [
+        "DESTRUCTION",
+        "SONS OF BEHEMAT",
+        "GARGANT",
+        "MEGA-GARGANT",
+        "MONSTER",
+        "HERO",
+        "GATEBREAKER"
+
+      ]
+    },
+    {
+      "name": "Bonegrinder Mega-Gargant",
+      "size": "130 mm",
+      "move": "See Damage Table",
+      "save": "4+",
+      "bravery": "7",
+      "wounds": "35",
+      "missile_weapon": [
+        {
+          "name": "Hurled Boulder",
+          "range": "See Damage Table",
+          "attacks": "1",
+          "to_hit": "3+",
+          "to_wound": "2+",
+          "rend": "-3",
+          "damage": "4"
+        }
+      ],
+      "melee_weapon": [
+        {
+          "name": "Gargantuan Club",
+          "range": "3",
+          "attacks": "See Damage Table",
+          "to_hit": "3+",
+          "to_wound": "3+",
+          "rend": "-2",
+          "damage": "3"
+        },
+        {
+          "name": "Thunderous Stomp",
+          "range": "1",
+          "attacks": "1",
+          "to_hit": "3+",
+          "to_wound": "3+",
+          "rend": "-2",
+          "damage": "D6"
+        }
+      ],
+      "abilites": [
+        {
+          "name": "Thunderous Stomp",
+          "desc": "You can re-roll hit rolls of 1 for Thunderous Stomp attacks unless the target is a Monster."
+        },
+        {
+          "name": "I’ll Bite Your Head Off!",
+          "desc": "After this model piles in, you can pick 1 enemy model that is within 3\" of this model, and roll a dice. If the roll is greater than that enemy model’s Wounds characteristic, that enemy model is slain."
+        },
+        {
+          "name": "Longshanks",
+          "desc": "When this model makes a normal move, it can ignore models that have a Wounds characteristic of 10 or less and terrain features that are less than 4\" tall at their highest point. It cannot finish the move on top of another model or within 3\" of an enemy model."
+        },
+        {
+          "name": "Son of Behemat",
+          "desc": "If a spell or ability would slay this model without any wounds or mortal wounds being inflicted by the spell or ability, this model suffers D6 mortal wounds instead."
+        },
+        {
+          "name": "Terror",
+          "desc": "Subtract 1 from the Bravery characteristic of enemy units if they are within 3\" of any friendly units with this ability."
+        },
+        {
+          "name": "Timberrr!",
+          "desc": "If this model is slain, before removing the model from the battlefield, the players must roll off. The winner must pick a point on the battlefield 5\" from this model. Each unit within 3\" of that point suffers D3 mortal wounds unless it is a Mega-Gargant. This model is then removed from the battlefield."
+        },
+        {
+          "name": "Mega-Club of Gork",
+          "desc": "Add 1 to the Bravery characteristic of friendly Orruk units while they are wholly within 12\" of this model."
+        }
+      ],
+      "damage_table": [
+        {
+          "wound_track_position": "1",
+          "move": "11",
+          "hurled_boulder": "18",
+          "gargantuan_club": "7",
+          "min_wounds_suffered": "0"
+        },
+        {
+          "wound_track_position": "2",
+          "move": "10",
+          "hurled_boulder": "15",
+          "gargantuan_club": "5",
+          "min_wounds_suffered": "13"
+        },
+        {
+          "wound_track_position": "3",
+          "move": "9",
+          "hurled_boulder": "12",
+          "gargantuan_club": "4",
+          "min_wounds_suffered": "19"
+        },
+        {
+          "wound_track_position": "4",
+          "move": "8",
+          "hurled_boulder": "9",
+          "gargantuan_club": "3",
+          "min_wounds_suffered": "25"
+        },
+        {
+          "wound_track_position": "5",
+          "move": "7",
+          "hurled_boulder": "6",
+          "gargantuan_club": "2",
+          "min_wounds_suffered": "31"
+        }
+        
+      ],
+      "keywords": [
+        "DESTRUCTION",
+        "SONS OF BEHEMAT",
+        "GARGANT",
+        "MEGA-GARGANT",
+        "MONSTER",
+        "BONEGRINDER"
+      ]
+    },
+    {
+      "name": "Mancrusher Gargant",
+      "size": "90 x 52 mm",
+      "move": "8",
+      "save": "5+",
+      "bravery": "7",
+      "wounds": "12",
+      "melee_weapon": [
+        {
+          "name": "'Eadbutt'",
+          "range": "1",
+          "attacks": "1",
+          "to_hit": "4+",
+          "to_wound": "3+",
+          "rend": "-3",
+          "damage": "See Damage Table"
+        },
+        {
+          "name": "Massive Club",
+          "range": "3",
+          "attacks": "See Damage Table",
+          "to_hit": "3+",
+          "to_wound": "3+",
+          "rend": "-1",
+          "damage": "1"
+        },
+        {
+          "name": "Mighty Kick",
+          "range": "2",
+          "attacks": "1",
+          "to_hit": "3+",
+          "to_wound": "3+",
+          "rend": "-2",
+          "damage": "D3"
+        }
+      ],
+      "abilites": [
+        {
+          "name": "Keep Up!",
+          "desc": "If this unit is within 12\" of a friendly Mega-Gargant at the start of the charge phase, it can attempt to charge in that charge phase even if it ran in the same turn."
+        },
+        {
+          "name": "Stomping Charge",
+          "desc": "After a model from this unit makes a charge move, pick 1 enemy unit within 1\" of it and roll a dice. If the roll is equal to or greater than the Stomping Charge value for the charging model shown on the damage table above, that unit suffers D3 mortal wounds. If this unit has more than 1 model, do not allocate the mortal wounds until all of the models in this unit have made their charge moves."
+        },
+        {
+          "name": "Stuff'Em In Me Bag",
+          "desc": "After a model from this unit piles in, you can pick 1 enemy model within 3\" of it and roll a dice. If the roll is at least double that model’s Wounds characteristic, it is slain."
+        },
+        {
+          "name": "Timber!",
+          "desc": "If a model from this unit is slain, before removing it from the battlefield, the players must roll off. The winner must pick a point on the battlefield 3\" from that model. Each unit within 2\" of that point suffers D3 mortal wounds unless it is a Gargant. The model is then removed from the battlefield."
+        }
+      ],
+      "damage_table": [
+        {
+          "wound_track_position": "1",
+          "stomping_charge": "2+",
+          "massive_club": "10",
+          "'eadbutt": "4",
+          "min_wounds_suffered": "0"
+        },
+        {
+          "wound_track_position": "2",
+          "stomping_charge": "3+",
+          "massive_club": "9",
+          "'eadbutt": "3",
+          "min_wounds_suffered": "3"
+        },
+        {
+          "wound_track_position": "3",
+          "stomping_charge": "4+",
+          "massive_club": "8",
+          "'eadbutt": "3",
+          "min_wounds_suffered": "5"
+        },
+        {
+          "wound_track_position": "4",
+          "stomping_charge": "5+",
+          "massive_club": "6",
+          "'eadbutt": "2",
+          "min_wounds_suffered": "8"
+        },
+        {
+          "wound_track_position": "5",
+          "stomping_charge": "6+",
+          "massive_club": "4",
+          "'eadbutt": "1",
+          "min_wounds_suffered": "10"
+        }
+        
+      ],
+      "keywords": [
+        "DESTRUCTION",
+        "SONS OF BEHEMAT",
+        "GARGANT",
+        "MONSTER",
+        "MANCRUSHER"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Description
Finished all the units in SoB, started Lumineth, added a unit to 3 other armies.

## List of changes

- added file sons_of_behemat.json
- finished updating all the units in sons_of_behemat.json
- added file lumineth_realm_lords.json
- not finished updating all the units in lumineth_realm_lords.json
- added a unit to gloomspite_gitz.json
- added a unit to monsters_of_chaos.json
- added a unit to beasts_of_chaos.json

